### PR TITLE
Handle the KeyError from record.get

### DIFF
--- a/ntdissector/ntds/ntds.py
+++ b/ntdissector/ntds/ntds.py
@@ -249,6 +249,13 @@ class NTDS:
             self.attributeSchema["cn"][cn_name] = self.datatable_columns_mapping.get(aid)
             self.attributeSchema["ldap"][ldap_name] = self.datatable_columns_mapping.get(aid)
 
+        def getRecordValue(record: Record, key: str):
+            """Wraps the record.get method to silently fail the return value to None for when the table is missing the requested column"""
+            try:
+                return record.get(key)
+            except KeyError:
+                return None
+
         seen = 0
         OCLID_classSchema = 196621
         OCLID_attributeSchema = 196622
@@ -271,12 +278,12 @@ class NTDS:
             _b_DNT = str(record.get("backlink_DNT"))
             if _b_DNT not in self.links["to"]:
                 self.links["to"][_b_DNT] = []
-            self.links["to"][_b_DNT].append((record.get("link_DNT"), record.get("link_base"), record.get("link_deltime"), record.get("link_deactivetime"), record.get("link_data")))
+            self.links["to"][_b_DNT].append((record.get("link_DNT"), record.get("link_base"), record.get("link_deltime"), getRecordValue(record, "link_deactivetime"), record.get("link_data")))
 
             _l_DNT = str(record.get("link_DNT"))
             if _l_DNT not in self.links["from"]:
                 self.links["from"][_l_DNT] = []
-            self.links["from"][_l_DNT].append((record.get("backlink_DNT"), record.get("link_base"), record.get("link_deltime"), record.get("link_deactivetime"), record.get("link_data")))
+            self.links["from"][_l_DNT].append((record.get("backlink_DNT"), record.get("link_base"), record.get("link_deltime"), getRecordValue(record, "link_deactivetime"), record.get("link_data")))
 
         logging.debug("Parsing the datatable")
         for record in self.__datatable.records():


### PR DESCRIPTION
Added a wrapper for record.get to silently handle the KeyError that is raised when a column does not exist. Fixes #6.