### PR TITLE
Determine cache key based on file content

### DIFF
--- a/ntdissector/ntds/ntds.py
+++ b/ntdissector/ntds/ntds.py
@@ -48,7 +48,7 @@ class NTDS:
 
     def __init__(self, ntdsFile, options=None) -> None:
         self.__dt_records_count = -1
-        self.__nfo = [ntdsFile, md5(b(ntdsFile)).hexdigest(), self.__dt_records_count]
+        self.__nfo = [ntdsFile, md5(open(ntdsFile, "rb").read()).hexdigest(), self.__dt_records_count]
         self.__db = EseDB(open(ntdsFile, "rb"))
         self.__datatable = self.__db.table("datatable")
         self.__linktable = self.__db.table("link_table")


### PR DESCRIPTION
Currently the name of the cache is based on the name of the input file. However, if you have two files called `ntds.dit` from different systems this will result in the incorrect cache being used for the second run, which results in incorrect data. This PR changes the cache to be dependent on the content of the ntds file.