### PR TITLE
Add error handling for link_table parsing

### DIFF
--- a/ntdissector/ntds/ntds.py
+++ b/ntdissector/ntds/ntds.py
@@ -1,4 +1,6 @@
 import logging
+
+from dissect.esedb import KeyNotFoundError
 from dissect.esedb.esedb import EseDB
 from dissect.esedb.record import Record
 from dissect.esedb.page import Page
@@ -268,15 +270,22 @@ class NTDS:
 
         logging.debug("Parsing the link_table")
         for record in self.__linktable.records():
+            try:
+                link_data = record.get("link_data")
+            except KeyNotFoundError:
+                logging.warning("Cannot find key for link_table record, ignoring record")
+                logging.debug(record)
+                continue
+
             _b_DNT = str(record.get("backlink_DNT"))
             if _b_DNT not in self.links["to"]:
                 self.links["to"][_b_DNT] = []
-            self.links["to"][_b_DNT].append((record.get("link_DNT"), record.get("link_base"), record.get("link_deltime"), record.get("link_deactivetime"), record.get("link_data")))
+            self.links["to"][_b_DNT].append((record.get("link_DNT"), record.get("link_base"), record.get("link_deltime"), record.get("link_deactivetime"), link_data))
 
             _l_DNT = str(record.get("link_DNT"))
             if _l_DNT not in self.links["from"]:
                 self.links["from"][_l_DNT] = []
-            self.links["from"][_l_DNT].append((record.get("backlink_DNT"), record.get("link_base"), record.get("link_deltime"), record.get("link_deactivetime"), record.get("link_data")))
+            self.links["from"][_l_DNT].append((record.get("backlink_DNT"), record.get("link_base"), record.get("link_deltime"), record.get("link_deactivetime"), link_data))
 
         logging.debug("Parsing the datatable")
         for record in self.__datatable.records():


### PR DESCRIPTION
I currently have an NTDS file where the `link_table` couldn't completely be parsed. One of the records results in the following error:

```
File "/Users/user/.virtualenvs/ntdissector/lib/python3.11/site-packages/dissect/esedb/cursor.py", line 110, in search
    raise KeyNotFoundError(f"Can't find key: {key}")
dissect.esedb.exceptions.KeyNotFoundError: Can't find key: b'<redacted>'
```

This PR adds a check for this, if this happens a warning is logged and the record is ignored. If there is any better way of handling this exception please let me know, would be happy to implement.