### PR TITLE
fix logic for ADAM/LDS

### DIFF
--- a/ntdissector/ntds/ntds.py
+++ b/ntdissector/ntds/ntds.py
@@ -111,8 +111,8 @@ class NTDS:
             self.__dt_records_count = self.__nfo[2]
 
         if self.__dryRun or not self.__cacheLoaded:
-            self.__getBootKey(options.bootKey, options.system)
             self.__buildSchemas()
+            self.__getBootKey(options.bootKey, options.system)
             if self.__persistCache:
                 self.__saveCache()
         else:
@@ -200,7 +200,6 @@ class NTDS:
             else:
                 root_permutation = [2, 4, 25, 9, 7, 27, 5, 11]
                 schema_permutation = [37, 2, 17, 36, 20, 11, 22, 7]
-                print(self.__schemaPekList[2])
                 self.bootKey = b"".join(
                     [self.__rootPekList[i].to_bytes(1, "little") for i in root_permutation]
                     + [self.__schemaPekList[i].to_bytes(1, "little") for i in schema_permutation]


### PR DESCRIPTION
Salut,

When ntdissector is used with an `adamntds.dit` file, passwords are not decrypted because the bootkey computation is performed before ADAM/LDS detection.

Before the PR

```bash
$ ntdissector -ntds adamntds.dit -debug
[!] No system bootKey
[*] Building the schemas, please wait...
[+] Parsing the sdtable
[+] Parsing the link_table
[+] Parsing the datatable
[+] ADAM_NTDS : Found rootPekList (len:40)
[+] ADAM_NTDS : Found Pek-List
[+] ADAM_NTDS : Found schemaPekList (len:40)
[+] Building distinguished names...
[+] Processing 2 unresolved DNs
[...]
[+] NTDS debug stats
>>> ESEDB Tables
* MSysObjects
* MSysObjectsShadow
* MSysObjids
* MSysLocales
* datatable
* hiddentable
* link_history_table
* link_table
* sdpropcounttable
* sdproptable
* sd_table
* MSysDefrag2
* quota_table
* quota_rebuild_progress_table

>>>> datatable
* columns=320
* data_tree_root_page=31
* lv_tree_root_page=263

>>> NTDS
* Hash: f[REDACTED]9
* isADAM: True
* Object Class Schema: 66
* Resolved Columns: 310/310
* Total Records: 4463
* Encrypted Pek List: 03000000000000000000000000000000000
* System Boot Key: None
* Decrypted Pek List: None

[+] Worker-1 started 
[+] Worker-2 started 

[...]

$ jq '.unicodePwd' /somewhere/.ntdissector/out/f[REDACTED]9/user.json 
"1300000000000000[REDCATED]a91e3ec8e"
"1300000000000000[REDCATED]9634ca"
"1300000000000000[REDCATED]e715"
"13000000000000000[REDCATED]32c40eb"
"13000000000000001[REDCATED]5db64db2"
"1300000000000000a[REDCATED]c52b19"
[...]
```

After the PR:

```bash
$ ntdissector -ntds adamntds.dit  -debug
[*] Building the schemas, please wait...
[+] Parsing the sdtable
[+] Parsing the link_table
[+] Parsing the datatable
[+] ADAM_NTDS : Found rootPekList (len:40)
[+] ADAM_NTDS : Found Pek-List
[+] ADAM_NTDS : Found schemaPekList (len:40)
[+] Building distinguished names...
[+] Processing 2 unresolved DNs
[+] Schemas built successfully : [ objectClassSchema=66 | attributeSchema=310 | pekList=Found | seen=4463]
[+] ADAM_NTDS: computer system bootKey from : 7[REDACTED]4
[...]
[*] PEK # 0 found and decrypted: 70[REDACTED]15f
[+] Decrypted pekList
[...]
[+] NTDS debug stats
>>> ESEDB Tables
* MSysObjects
* MSysObjectsShadow
* MSysObjids
* MSysLocales
* datatable
* hiddentable
* link_history_table
* link_table
* sdpropcounttable
* sdproptable
* sd_table
* MSysDefrag2
* quota_table
* quota_rebuild_progress_table

>>>> datatable
* columns=320
* data_tree_root_page=31
* lv_tree_root_page=263

>>> NTDS
* Hash: f[REDACTED]9
* isADAM: True
* Object Class Schema: 66
* Resolved Columns: 310/310
* Total Records: 4463
* Encrypted Pek List: 0300000001000[REDACTED]c00000000000000000000000000000000
* System Boot Key: 70[REDACTED]15f
* Decrypted Pek List: ['7[REDACTED]5f']

[+] Worker-1 started 
[+] Worker-2 started 
[+] Worker-3 started 


$ jq '.unicodePwd' /somewhere/.ntdissector/out/f[REDACTED]9/user.json 
"0be[REDCATED]4d8"
"fde[REDACTED]6c0"
```

:sunflower: