### PR TITLE
Compute AES inter-realm trust keys

### DIFF
--- a/ntdissector/ntds/ntds.py
+++ b/ntdissector/ntds/ntds.py
@@ -650,6 +650,9 @@ class NTDS:
 
     def __formatTrust(self, obj: dict) -> None:
         if "trustedDomain" in obj["objectClass"]:
+            domain = obj["distinguishedName"].split("DC=", 1)[-1].replace("DC=", "").replace(",", ".")
+            trust_partner = obj["trustPartner"]
+
             if "securityIdentifier" in obj:
                 try:
                     obj["securityIdentifier"] = NTDS_SID(unhexlify(obj["securityIdentifier"])).formatCanonical()
@@ -657,7 +660,7 @@ class NTDS:
                     pass
             for attr in ["trustAuthIncoming", "trustAuthOutgoing"]:
                 try:
-                    obj[attr] = TRUST_AUTH_INFO(obj[attr])._toJson()
+                    obj[attr] = TRUST_AUTH_INFO(obj[attr], domain, trust_partner, attr)._toJson()
                 except Exception as e:
                     pass
 

--- a/ntdissector/utils/trusts.py
+++ b/ntdissector/utils/trusts.py
@@ -1,7 +1,9 @@
 from binascii import hexlify
+from impacket.krb5.crypto import string_to_key
 from impacket.structure import Structure
 from Cryptodome.Hash import MD4
 from . import fileTimeToDateTime
+from .constants import KERBEROS_TYPE
 
 
 # 6.1.6.9.1 trustAuthInfo Attributes
@@ -19,17 +21,17 @@ class TRUST_AUTH_INFO(Structure):
         ("PreviousAuthenticationInformationData", ":"),
     )
 
-    def __init__(self, data):
+    def __init__(self, data, domain, trust_partner, trust_direction):
         Structure.__init__(self, data)
 
         self["AuthenticationInformation"] = []
         self["PreviousAuthenticationInformation"] = []
 
         for aif in ["AuthenticationInformation", "PreviousAuthenticationInformation"]:
-            self[aif].append(LSAPR_AUTH_INFORMATION(self[f"{aif}Data"]))
+            self[aif].append(LSAPR_AUTH_INFORMATION(self[f"{aif}Data"], domain, trust_partner, trust_direction))
 
             while len(self[aif][-1]["Remaining"]) > 0:
-                self[aif].append(LSAPR_AUTH_INFORMATION(self[aif][-1]["Remaining"]))
+                self[aif].append(LSAPR_AUTH_INFORMATION(self[aif][-1]["Remaining"], domain, trust_partner, trust_direction))
 
     def _toJson(self):
         obj = {"count": self["Count"]}
@@ -58,7 +60,7 @@ class LSAPR_AUTH_INFORMATION(Structure):
         3: "TRUST_AUTH_TYPE_VERSION",
     }
 
-    def __init__(self, data):
+    def __init__(self, data, domain, trust_partner, trust_direction):
         Structure.__init__(self, data)
 
         self["AuthType"] = self.__LSA_AUTH_INFORMATION_AUTH_TYPES[self["AuthType"]]
@@ -66,13 +68,29 @@ class LSAPR_AUTH_INFORMATION(Structure):
         # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/cd20fbd1-eabe-4da2-bba3-31ab3036d019
         if self["AuthType"] == "TRUST_AUTH_TYPE_CLEAR":
             # derive RC4 key
-            self["AuthInfo_RC4-HMAC"] = MD4.new(self["AuthInfo"]).digest()
+            self["AuthInfo_RC4_HMAC"] = MD4.new(self["AuthInfo"]).digest()
+
+            # derive AES keys
+            if trust_direction == "trustAuthIncoming":
+                salt = f"{domain.upper()}krbtgt{trust_partner.upper()}".encode("utf-8")
+            else:  # trustAuthOutgoing
+                salt = f"{trust_partner.upper()}krbtgt{domain.upper()}".encode("utf-8")
+
+            password = self["AuthInfo"].decode("utf-16-le", "replace").encode("utf-8", "replace")
+
+            aes_etypes = {k: v.upper() for k, v in KERBEROS_TYPE.items() if "aes" in v}
+            for etype_dec, etype_name in aes_etypes.items():
+                key = string_to_key(etype_dec, password, salt, None)
+                self[f"AuthInfo_{etype_name}"] = hexlify(key.contents).decode("utf-8")
+
             # to:do ? DES-CBC / DEC-CRC
         elif self["AuthType"] == "TRUST_AUTH_TYPE_NT4OWF":
-            self["AuthInfo_RC4-HMAC"] = self["AuthInfo"]
+            self["AuthInfo_RC4_HMAC"] = self["AuthInfo"]
 
     def _toJson(self):
         obj = {"lastUpdateTime": fileTimeToDateTime(self["LastUpdateTime"]), "authType": self["AuthType"], "authInfo": self["AuthInfo"]}
-        if "AuthInfo_RC4-HMAC" in self.fields:
-            obj["authInfo_RC4-HMAC"] = self["AuthInfo_RC4-HMAC"]
+        supported_etypes = [v.upper() for v in KERBEROS_TYPE.values() if "aes" in v or "rc4" in v]
+        for etype in supported_etypes:
+            if f"AuthInfo_{etype}" in self.fields:
+                obj[f"authInfo_{etype}"] = self[f"AuthInfo_{etype}"]
         return obj


### PR DESCRIPTION
Add generation of AES inter-realm trust keys.

The salt used is documented in Mimikatz code: https://github.com/gentilkiwi/mimikatz/blob/152b208916c27d7d1fc32d10e64879721c4d06af/mimikatz/modules/kuhl_m_lsadump.c#L1657