### PR TITLE
Fix pickle errors

### DIFF
--- a/ntdissector/ntds/ntds.py
+++ b/ntdissector/ntds/ntds.py
@@ -760,7 +760,7 @@ class NTDS:
         stats = dict()
 
         def __reduce(record):
-            return {"page_num": record._node.tag.page.num, "page_buf": bytes(record._node.tag.page.buf), "node_num": record._node.num}
+            return {"page_num": int(record._node.tag.page.num), "page_buf": bytes(record._node.tag.page.buf), "node_num": int(record._node.num)}
 
         workersQ = mp.Queue()
         workerLock = mp.Lock()

--- a/ntdissector/ntds/ntds.py
+++ b/ntdissector/ntds/ntds.py
@@ -448,7 +448,7 @@ class NTDS:
                 res["Primary:WDigest"] = list()
                 try:
                     wDigestCreds = WDIGEST_CREDENTIALS(creds.split(unhexlify("0100000001000000e80100000600000001000000e0010000"))[1])
-                except:
+                except Exception as e:
                     logging.error("__formatSupplementalCredentialsInfo (ADAM) : %s" % e)
                     return
                 for j in range(wDigestCreds["NumberOfHashes"]):


### PR DESCRIPTION
On some specific case regarding ESE structure (when page is generated from this line https://github.com/fox-it/dissect.esedb/blob/e0d6bf41eb54712c0d9c4858682a2e92132874fd/dissect/esedb/page.py#L162), the page_num will be an types.uint32, and not an int and can't be serialized by pickle. Thus the page won't be processed and associated data are lost (in my case just 2 records out of 15K).

This pr ensure values that will be serialized can be serialize by pickle.

Error that was generated before the PR :
```
Traceback (most recent call last):
  File "/usr/lib/python3.10/multiprocessing/queues.py", line 244, in _feed
    obj = _ForkingPickler.dumps(obj)
  File "/usr/lib/python3.10/multiprocessing/reduction.py", line 51, in dumps
    cls(buf, protocol).dump(obj)
_pickle.PicklingError: Can't pickle <class 'types.uint32'>: attribute lookup uint32 on types failed
```