### PR TITLE
dissect.esedb upgraded to dissect.database

### DIFF
--- a/ntdissector/ntds/ntds.py
+++ b/ntdissector/ntds/ntds.py
@@ -760,7 +760,7 @@ class NTDS:
         stats = dict()
 
         def __reduce(record):
-            return {"page_num": record._node.tag.page.num, "page_buf": bytes(record._node.tag.page.buf), "node_num": record._node.num}
+            return {"page_num": int(record._node.tag.page.num), "page_buf": bytes(record._node.tag.page.buf), "node_num": int(record._node.num)}
 
         workersQ = mp.Queue()
         workerLock = mp.Lock()

--- a/ntdissector/ntds/ntds.py
+++ b/ntdissector/ntds/ntds.py
@@ -448,7 +448,7 @@ class NTDS:
                 res["Primary:WDigest"] = list()
                 try:
                     wDigestCreds = WDIGEST_CREDENTIALS(creds.split(unhexlify("0100000001000000e80100000600000001000000e0010000"))[1])
-                except:
+                except Exception as e:
                     logging.error("__formatSupplementalCredentialsInfo (ADAM) : %s" % e)
                     return
                 for j in range(wDigestCreds["NumberOfHashes"]):

--- a/ntdissector/ntds/ntds.py
+++ b/ntdissector/ntds/ntds.py
@@ -1,7 +1,5 @@
 import logging
-from dissect.esedb.esedb import EseDB
-from dissect.esedb.record import Record
-from dissect.esedb.page import Page
+from dissect.database.ese import ESE, Record, Page
 from impacket.dcerpc.v5.samr import (
     USER_PROPERTIES,
     USER_PROPERTY,
@@ -49,7 +47,7 @@ class NTDS:
     def __init__(self, ntdsFile, options=None) -> None:
         self.__dt_records_count = -1
         self.__nfo = [ntdsFile, md5(b(ntdsFile)).hexdigest(), self.__dt_records_count]
-        self.__db = EseDB(open(ntdsFile, "rb"))
+        self.__db = ESE(open(ntdsFile, "rb"))
         self.__datatable = self.__db.table("datatable")
         self.__linktable = self.__db.table("link_table")
         self.__sdtable = self.__db.table("sd_table")
@@ -715,7 +713,7 @@ class NTDS:
         wid = mp.current_process().name.split("-")[1]
         results = dict()
         logging.debug(f"Worker-{wid} started ")
-        self.__db = EseDB(open(self.__nfo[0], "rb"))
+        self.__db = ESE(open(self.__nfo[0], "rb"))
         self.__datatable = self.__db.table("datatable")
         self.__linktable = self.__db.table("link_table")
         while True:
@@ -729,7 +727,7 @@ class NTDS:
                             outFile.write("\n")
                 break
             else:
-                node = Page(esedb=self.__db, num=pickled_record["page_num"], buf=pickled_record["page_buf"]).node(num=pickled_record["node_num"])
+                node = Page(db=self.__db, num=pickled_record["page_num"], buf=pickled_record["page_buf"]).node(num=pickled_record["node_num"])
                 record = Record(table=self.__datatable, node=node)
                 res_obj = self.__serializeRecord(record)
                 # logging.debug(res_obj)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dissect.esedb>=3.9
+dissect.database
 impacket==0.10.0
 pycryptodome>=3.17
 pycryptodomex>=3.17

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.13",
     ],
     keywords="ntdissector ntds esedb",
     packages=find_packages(),


### PR DESCRIPTION
Since `dissect.esedb` library has been archived, `dissect.database` is now its replacement and is actively maintained. This pull request upgrades the library to take advantage of new features and existing bug fixes.

Additionally, this PR updates the project to Python 3.13, which is available on Debian’s upcoming "Trixie" release.

Finally, the changes from @william-billaud's pull request were tested and successfully resolve the Pickle typing issues.